### PR TITLE
Standalone (non-SDL2) compile fixes

### DIFF
--- a/mojoshader_vulkan.c
+++ b/mojoshader_vulkan.c
@@ -218,7 +218,7 @@ static MOJOSHADER_vkBufferWrapper *create_ubo_backing_buffer(
     MOJOSHADER_vkBufferWrapper *newBuffer = (MOJOSHADER_vkBufferWrapper *) ctx->malloc_fn(
         sizeof(MOJOSHADER_vkBufferWrapper), ctx->malloc_data
     );
-    SDL_zerop(newBuffer);
+    memset(newBuffer, '\0', sizeof(MOJOSHADER_vkBufferWrapper));
 
     newBuffer->size = ubo->internalBufferSize;
 

--- a/profiles/mojoshader_profile_spirv.c
+++ b/profiles/mojoshader_profile_spirv.c
@@ -2327,10 +2327,10 @@ void emit_SPIRV_finalize(Context *ctx)
     spv_emit_vs_main_end(ctx);
     spv_emit_func_lit(ctx);
 
-    uint8_t emit_vec4 = ctx->uniform_float4_count > 0 && ctx->spirv.uniform_arrays.idvec4;
-    uint8_t emit_ivec4 = ctx->uniform_int4_count > 0 && ctx->spirv.uniform_arrays.idivec4;
-    uint8_t emit_bool = ctx->uniform_bool_count > 0 && ctx->spirv.uniform_arrays.idbool;
-    uint8_t emit_any = emit_vec4 | emit_ivec4 | emit_bool;
+    uint8 emit_vec4 = ctx->uniform_float4_count > 0 && ctx->spirv.uniform_arrays.idvec4;
+    uint8 emit_ivec4 = ctx->uniform_int4_count > 0 && ctx->spirv.uniform_arrays.idivec4;
+    uint8 emit_bool = ctx->uniform_bool_count > 0 && ctx->spirv.uniform_arrays.idbool;
+    uint8 emit_any = emit_vec4 | emit_ivec4 | emit_bool;
     if (ctx->spirv.mode == SPIRV_MODE_GL)
     {
         if (emit_vec4)


### PR DESCRIPTION
Fixed a few compile errors that occur when building MojoShader without SDL2, particularly with MSVC.